### PR TITLE
Use #class_attribute instead of #attr_accessor

### DIFF
--- a/lib/active_job/traffic_control/concurrency.rb
+++ b/lib/active_job/traffic_control/concurrency.rb
@@ -8,12 +8,10 @@ module ActiveJob
       CONCURRENCY_REENQUEUE_DELAY = ENV["RACK_ENV"] == "test" ? 1...5 : 30...(60 * 5)
 
       class_methods do
-        attr_accessor :job_concurrency
-
         def concurrency(threshold, drop: true, key: nil, wait_timeout: 0.1, stale_timeout: 60 * 10)
           raise ArgumentError, "Concurrent jobs needs to be an integer > 0" if threshold.to_i < 1
 
-          @job_concurrency = {
+          self.job_concurrency = {
             threshold: threshold.to_i,
             drop: drop,
             wait_timeout: wait_timeout.to_f,
@@ -29,6 +27,8 @@ module ActiveJob
 
       included do
         include ActiveJob::TrafficControl::Base
+
+        class_attribute :job_concurrency, instance_accessor: false
 
         around_perform do |job, block|
           if self.class.job_concurrency.present?

--- a/lib/active_job/traffic_control/throttle.rb
+++ b/lib/active_job/traffic_control/throttle.rb
@@ -6,12 +6,10 @@ module ActiveJob
       extend ::ActiveSupport::Concern
 
       class_methods do
-        attr_accessor :job_throttling
-
         def throttle(threshold:, period:, drop: false, key: nil)
           raise ArgumentError, "Threshold needs to be an integer > 0" if threshold.to_i < 1
 
-          @job_throttling = {
+          self.job_throttling = {
             threshold: threshold,
             period: period,
             drop: drop,
@@ -26,6 +24,8 @@ module ActiveJob
 
       included do
         include ActiveJob::TrafficControl::Base
+
+        class_attribute :job_throttling, instance_accessor: false
 
         around_perform do |job, block|
           if self.class.job_throttling.present?


### PR DESCRIPTION
See: https://github.com/rails/rails/blob/v5.0.0.1/activejob/lib/active_job/queue_priority.rb#L29-L33

Also, it prevents wrong data in inherited classes.