### PR TITLE
Add note to README about Redis and Memcached for testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ end
 
 ## Development
 
+The test suite tests both Redis and Memcached as backends; you will need both of them installed.
+
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake test` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
 
 To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).


### PR DESCRIPTION
I tried to run the test suite and had connection failures because I didn't have Memcached running. I had checked for a "CONTRIBUTING" file but the only instructions I found for development were the boilerplate in the README.

This PR just adds a line to the README to note that you need both backends running.

Let me know if you want me to expand this (e.g. `brew install redis memcached` for macOS) or change any wording.