### PR TITLE
Concurrency and Throttle cannot both be used on a job

### DIFF
--- a/lib/active_job/traffic_control/base.rb
+++ b/lib/active_job/traffic_control/base.rb
@@ -24,12 +24,10 @@ module ActiveJob
             if config_attr[:key].respond_to?(:call)
               "traffic_control:#{prefix}:#{config_attr[:key].call(job)}"
             else
-              @static_job_key ||= begin
-                if config_attr[:key].present?
-                  "traffic_control:#{prefix}:#{config_attr[:key]}"
-                else
-                  "traffic_control:#{prefix}:#{cleaned_name}"
-                end
+              if config_attr[:key].present?
+                "traffic_control:#{prefix}:#{config_attr[:key]}"
+              else
+                "traffic_control:#{prefix}:#{cleaned_name}"
               end
             end
           end

--- a/test/active_job/traffic_control_test.rb
+++ b/test/active_job/traffic_control_test.rb
@@ -95,6 +95,14 @@ module ActiveJob::TrafficControlTest
     end
   end
 
+  class ThrottleConcurrencyTestJob < ActiveJob::Base
+    throttle threshold: 2, period: 1.second, drop: true
+    concurrency 1, drop: true
+
+    def perform
+    end
+  end
+
   def test_that_it_has_a_version_number
     refute_nil ::ActiveJob::TrafficControl::VERSION
   end
@@ -195,6 +203,13 @@ module ActiveJob::TrafficControlTest
   def test_everything_at_once
     EverythingBaseJob.perform_now
     assert_equal 1, $count
+  end
+
+  def test_throttle_concurrency_different_keys
+    job = ThrottleConcurrencyTestJob.new
+    throttle = ThrottleConcurrencyTestJob.throttling_lock_key(job)
+    concurrency = ThrottleConcurrencyTestJob.concurrency_lock_key(job)
+    refute_equal throttle, concurrency
   end
 end
 


### PR DESCRIPTION
While the use case for this is likely slim (only one job can be run at a time and no more than 2 in a second or something), there's a possibility that you would want to have both `concurrency` and `throttle` on the same job. This would fail with non-`proc` keys because the `::lock_key` method is memoizing the return value when called by the first strategy to acquire a lock, and the second strategy would get the same key. 

This resolves that by removing the memoization. That was part of the original design, but in that case each individual strategy memoized it's own lock (e.g. `@concurrency_key`). In 6fe8aad4 with refactoring for Rails 5 this changed to a common `Base::lock_key` method and the memoization became shared.

I don't think that the memoization adds much. The calls that are memoized are a hash lookup, string interpolation, and `gsub`, none of which are that complex. Additionally, `::lock_key` looks like it's only called once per job, so memoization probably has no effect.

This PR includes a test to verify that the keys are different. That seemed a simpler test (and more determinate) that trying to contrive a situation to prove that both locks are working. It also more clearly documents the thing being asserted. Let me know if this works or if you would like more coverage.