### PR TITLE
support redis-namespace client

### DIFF
--- a/activejob-traffic_control.gemspec
+++ b/activejob-traffic_control.gemspec
@@ -28,4 +28,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "minitest", "~> 5.0"
   spec.add_development_dependency "codeclimate-test-reporter", "~> 0.4.7"
   spec.add_development_dependency "connection_pool"
+  spec.add_development_dependency "redis-namespace", "~> 1.6"
 end

--- a/lib/active_job/traffic_control.rb
+++ b/lib/active_job/traffic_control.rb
@@ -58,7 +58,7 @@ module ActiveJob
       def client_class_type(client)
         if client.instance_of?(Dalli::Client)
           Suo::Client::Memcached
-        elsif client.instance_of?(::Redis)
+        elsif client.instance_of?(::Redis) || client.instance_of?(::Redis::Namespace)
           Suo::Client::Redis
         else
           raise ArgumentError, "Unsupported client type: #{client}"

--- a/lib/active_job/traffic_control.rb
+++ b/lib/active_job/traffic_control.rb
@@ -58,7 +58,7 @@ module ActiveJob
       def client_class_type(client)
         if client.instance_of?(Dalli::Client)
           Suo::Client::Memcached
-        elsif client.instance_of?(::Redis) || client.instance_of?(::Redis::Namespace)
+        elsif client.instance_of?(::Redis) || defined?(::Redis::Namespace) && client.instance_of?(::Redis::Namespace)
           Suo::Client::Redis
         else
           raise ArgumentError, "Unsupported client type: #{client}"

--- a/test/active_job/traffic_control_test.rb
+++ b/test/active_job/traffic_control_test.rb
@@ -235,3 +235,23 @@ class RedisPooledTrafficControlTest < Minitest::Test
     setup_globals
   end
 end
+
+class RedisNamespacedTrafficControlTest < Minitest::Test
+  include ActiveJob::TrafficControlTest
+
+  def setup
+    ActiveJob::TrafficControl.client = Redis::Namespace.new(:namespace, redis: Redis.new)
+    setup_globals
+  end
+end
+
+class RedisNamespacedPooldedTrafficControlTest < Minitest::Test
+  include ActiveJob::TrafficControlTest
+
+  def setup
+    ActiveJob::TrafficControl.client = ConnectionPool.new(size: 5, timeout: 5) do
+      Redis::Namespace.new(:namespace, redis: Redis.new)
+    end
+    setup_globals
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -14,6 +14,7 @@ require "connection_pool"
 require "activejob/traffic_control"
 require "active_job"
 require "minitest/autorun"
+require "redis/namespace"
 
 test_logger = begin
   l = Logger.new(STDOUT)


### PR DESCRIPTION
[redis-namespace](https://github.com/resque/redis-namespace) is a tiny wrapper around redis-rb that adds support for namespaces. It behaves exactly the same as redis-rb, so it should be supported by this gem. This PR adds support and tests for it.

To init the client you simply do:

```rb
ActiveJob::TrafficControl.client = Redis::Namespace.new(:namespace, redis: Redis.new)
```

Everything seems to work as it should (according to the tests).