### PR TITLE
Bugfix: Wrong option name passed to Suo for `wait_timeout` option

### DIFF
--- a/lib/active_job/traffic_control/concurrency.rb
+++ b/lib/active_job/traffic_control/concurrency.rb
@@ -34,7 +34,7 @@ module ActiveJob
           if self.class.job_concurrency.present?
             lock_options = {
               resources: self.class.job_concurrency[:threshold],
-              acquisition_lock: self.class.job_concurrency[:wait_timeout],
+              acquisition_timeout: self.class.job_concurrency[:wait_timeout],
               stale_lock_expiration: self.class.job_concurrency[:stale_timeout]
             }
 


### PR DESCRIPTION
The parameter needed to control `wait_timeout` is named `acquisition_timeout` in Suo (https://github.com/nickelser/suo/blob/master/lib/suo/client/base.rb#L5) not `acquisition_lock`.

Essentially the current `wait_timeout` option is a no-op; it doesn't control anything. This PR fixes this and passes the correct parameter name to the Suo lock.