### PR TITLE
Do not assume redis or dalli are available

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,6 @@ source "https://rubygems.org"
 
 # Specify your gem's dependencies in activejob-traffic_control.gemspec
 gemspec
+
+gem 'redis'
+gem 'dalli'

--- a/README.md
+++ b/README.md
@@ -4,19 +4,27 @@ Rate controls for your `ActiveJob`s, powered by [Suo](https://github.com/nickels
 
 ## Installation
 
-Add this line to your application's Gemfile:
+1. Add this line to your application's Gemfile:
 
-```ruby
-gem 'activejob-traffic_control'
-```
+   ```ruby
+   gem 'activejob-traffic_control'
+   ```
 
-And then execute:
+2. Add `dalli` if you want to use Memcached or `redis` if you want to use Redis.
 
-    $ bundle
+   ```ruby
+   # Memcached
+   gem 'dalli'
 
-Or install it yourself as:
+   # Redis
+   gem 'redis'
+   ```
 
-    $ gem install activejob-traffic_control
+3. And then execute:
+
+   ```bash
+   $ bundle
+   ```
 
 ## Usage
 
@@ -73,8 +81,11 @@ end
 For `Disable`, you also need to configure the cache client:
 
 ```ruby
-ActiveJob::TrafficControl.cache_client = Rails.cache.dalli # if using :dalli_store
-# or ActiveJob::TrafficControl.cache_client = ActiveSupport::Cache.lookup_store(:dalli_store, "localhost:11211")
+# Memcached
+ActiveJob::TrafficControl.cache_client = ActiveSupport::Cache.lookup_store(:mem_cache_store, "localhost:11211")
+
+# Redis
+ActiveJob::TrafficControl.cache_client = ActiveSupport::Cache.lookup_store(:redis_cache_store)
 ```
 
 ```ruby

--- a/lib/active_job/traffic_control.rb
+++ b/lib/active_job/traffic_control.rb
@@ -56,9 +56,9 @@ module ActiveJob
       end
 
       def client_class_type(client)
-        if client.instance_of?(Dalli::Client)
+        if defined?(::Dalli::Client) && client.instance_of?(::Dalli::Client)
           Suo::Client::Memcached
-        elsif client.instance_of?(::Redis)
+        elsif defined?(::Redis) && client.instance_of?(::Redis)
           Suo::Client::Redis
         else
           raise ArgumentError, "Unsupported client type: #{client}"

--- a/test/active_job/traffic_control_test.rb
+++ b/test/active_job/traffic_control_test.rb
@@ -203,7 +203,7 @@ class MemcachedTrafficControlTest < Minitest::Test
 
   def setup
     ActiveJob::TrafficControl.client = Dalli::Client.new
-    ActiveJob::TrafficControl.cache_client = ActiveSupport::Cache.lookup_store(:dalli_store, "localhost:11211")
+    ActiveJob::TrafficControl.cache_client = ActiveSupport::Cache.lookup_store(:mem_cache_store, "localhost:11211")
     setup_globals
   end
 end
@@ -213,7 +213,7 @@ class MemcachedPooledTrafficControlTest < Minitest::Test
 
   def setup
     ActiveJob::TrafficControl.client = ConnectionPool.new(size: 5, timeout: 5) { Dalli::Client.new }
-    ActiveJob::TrafficControl.cache_client = ActiveSupport::Cache.lookup_store(:dalli_store, "localhost:11211", pool_size: 5)
+    ActiveJob::TrafficControl.cache_client = ActiveSupport::Cache.lookup_store(:mem_cache_store, "localhost:11211", pool_size: 5)
     setup_globals
   end
 end
@@ -223,6 +223,7 @@ class RedisTrafficControlTest < Minitest::Test
 
   def setup
     ActiveJob::TrafficControl.client = Redis.new
+    ActiveJob::TrafficControl.cache_client = ActiveSupport::Cache.lookup_store(:redis_cache_store)
     setup_globals
   end
 end
@@ -232,6 +233,7 @@ class RedisPooledTrafficControlTest < Minitest::Test
 
   def setup
     ActiveJob::TrafficControl.client = ConnectionPool.new(size: 5, timeout: 5) { Redis.new }
+    ActiveJob::TrafficControl.cache_client = ActiveSupport::Cache.lookup_store(:redis_cache_store, pool_size: 5)
     setup_globals
   end
 end


### PR DESCRIPTION
Makes it explicit that `dalli` or `redis` are used. Any maybe `suo` will drop the dependency on it, see https://github.com/nickelser/suo/pull/18, so we are prepared.