### PR TITLE
Support setting false-y values for cache_client

### DIFF
--- a/lib/active_job/traffic_control.rb
+++ b/lib/active_job/traffic_control.rb
@@ -17,7 +17,9 @@ module ActiveJob
       attr_accessor :client_klass
 
       def cache_client
-        @cache_client ||= begin
+        return @cache_client if defined?(@cache_client)
+
+        @cache_client = begin
           if defined?(Rails.cache)
             Rails.cache
           else

--- a/lib/active_job/traffic_control/disable.rb
+++ b/lib/active_job/traffic_control/disable.rb
@@ -13,10 +13,14 @@ module ActiveJob
 
       class_methods do
         def disable!(drop: false)
+          return false unless cache_client
+
           cache_client.write(disable_key, drop ? SHOULD_DROP : SHOULD_DISABLE)
         end
 
         def enable!
+          return false unless cache_client
+
           cache_client.delete(disable_key)
         end
 

--- a/test/active_job/traffic_control_test.rb
+++ b/test/active_job/traffic_control_test.rb
@@ -113,6 +113,9 @@ module ActiveJob::TrafficControlTest
     DisableTestJob.enable!
     DisableTestJob.perform_now
     assert_equal 2, $count
+
+    ActiveJob::TrafficControl.cache_client = false
+    DisableTestJob.perform_now
   end
 
   def throttle_helper(klass)


### PR DESCRIPTION
Given an app that

- Does not use this gem's `disabled?` functionality
- Rails.cache is a file store

This gem then prepends every job execution with a file read. This isn't a big deal, but setting `ActiveJob::TrafficControl.cache_client = false` has no effect, despite the library having support for a false-y `cache_client`. This is due to [usage of](https://github.com/nickelser/activejob-traffic_control/blob/master/lib/active_job/traffic_control.rb#L20) `||=` and the default of `Rails.cache`.